### PR TITLE
First round of lightweight improvements

### DIFF
--- a/1.0/IT/index.markdown
+++ b/1.0/IT/index.markdown
@@ -1,18 +1,18 @@
-# DICHIARAZIONE DEI PRINCIPI MYDATA
+# DICHIARAZIONE DEI PRINC&Igrave;PI MYDATA
 
 Poiché l'importanza dei dati personali nella società continua ad espandersi, diventa sempre più urgente assicurarsi che le persone siano in grado di conoscere e controllare i propri dati personali, ma anche di acquisirne conoscenza personale e rivendicarne i benefici.
 
-Oggi, l'equilibrio del potere è fortemente orientato verso le organizzazioni, che da sole hanno il potere di raccogliere, scambiare e prendere decisioni basate su dati personali, mentre gli individui possono solo sperare, con molta difficoltà, di ottenere il controllo di ciò che accade con i loro dati . I cambiamenti e i principi che esponiamo in questa Dichiarazione mirano a ristabilire l'equilibrio e ad progredire verso una visione più umana dei dati personali. Riteniamo che siano le condizioni per una società digitale giusta, sostenibile e prospera, le cui basi sono:
+Oggi, l'equilibrio del potere è fortemente orientato verso le organizzazioni, che da sole hanno il potere di raccogliere, scambiare e prendere decisioni basate su dati personali, mentre gli individui possono solo sperare, con molta difficoltà, di ottenere il controllo di ciò che accade con i loro dati. I cambiamenti e i princ&igrave;pi che esponiamo in questa Dichiarazione mirano a ristabilire l'equilibrio e a progredire verso una visione più umana dei dati personali. Riteniamo che siano le condizioni per una società digitale giusta, sostenibile e prospera, le cui basi sono:
 
-* Trust e sicurezza, che poggiano su relazioni equilibrate ed eque tra le persone, così come tra persone e organizzazioni;
+* Fiducia e sicurezza, che poggiano su relazioni equilibrate ed eque tra le persone, così come tra persone e organizzazioni;
 
-* Autodeterminazione, che viene raggiunta non solo dalla protezione legale, ma anche da azioni proattive per condividere il potere dei dati con gli individui;
+* Autodeterminazione, che viene raggiunta non solo dalla protezione legale, ma anche da azioni proattive per condividere il potere dei dati con le persone;
 
-* Massimizzare i benefici collettivi dei dati personali, condividendoli equamente tra organizzazioni, individui e società.
+* Massimizzare i benefici collettivi dei dati personali, condividendoli equamente tra organizzazioni, persone e società.
 
-## 1. MYDATA: COSA E’ NECESSARIO CAMBIARE
+## 1. MYDATA: COSA &Egrave; NECESSARIO CAMBIARE
 
-Il nostro obiettivo principale è consentire alle persone di utilizzare i propri dati personali ai propri fini e condividerli in modo sicuro secondo le proprie condizioni. Applicheremo e praticheremo questo approccio umano-centrico ai nostri servizi, e costruiremo strumenti e condivideremo le conoscenze per aiutare gli altri a fare lo stesso.
+Il nostro obiettivo principale è consentire alle persone di utilizzare i propri dati personali ai propri fini e condividerli in modo sicuro secondo le proprie condizioni. Applicheremo e praticheremo questo approccio incentrato sulla persona ai nostri servizi, e costruiremo strumenti e condivideremo le conoscenze per aiutare gli altri a fare lo stesso.
 
 ### 1.1. DAL DIRITTO FORMALE AL DIRITTO PERSEGUIBILE
 
@@ -26,88 +26,88 @@ La normativa sulla protezione dei dati e i codici etici aziendali sono progettat
 
 ### 1.3. VERSO GLI ECOSISTEMI APERTI
 
-L'economia dei dati di oggi crea effetti di rete favorendo alcune piattaforme in grado di raccogliere ed elaborare le masse di dati personali. Queste piattaforme bloccano i mercati, non solo per i loro concorrenti, ma anche per la maggior parte delle aziende che rischiano di perdere l'accesso diretto ai propri clienti. Permettendo agli individui di controllare ciò che accade ai loro dati, intendiamo creare un flusso di dati veramente libero, liberamente deciso dagli individui, libero da strozzature globali, e creare equilibrio, equità, diversità e competizione nell'economia digitale.
+L'economia dei dati di oggi crea effetti di rete favorendo alcune piattaforme in grado di raccogliere ed elaborare le masse di dati personali. Queste piattaforme chiudono i mercati, non solo ai loro concorrenti, ma anche alla maggior parte delle aziende che rischiano di perdere l'accesso diretto ai propri clienti. Permettendo alle persone di controllare ciò che accade ai loro dati, intendiamo creare un flusso di dati veramente libero, liberamente deciso dalle persone, libero da strozzature a livello globale, e creare equilibrio, equità, diversità e competizione nell'economia digitale.
 
 ## 2. LE COMPONENTI DI MYDATA: CHI FA COSA?
 
-_NOTA: I "**ruoli**" non sono “**Attori**” una persona o un'organizzazione può soddisfare uno o più ruoli contemporaneamente._
+_NOTA: I "**Ruoli**" non sono “**Attori**” una persona o un'organizzazione può soddisfare uno o più ruoli contemporaneamente._
 
 ![MYDATA ROLES](image_0.png)
 
-### PERSON
+### PERSONA (PERSONA)
 
 Un individuo che gestisce l'uso dei propri dati personali, per i propri scopi, e mantiene relazioni con altri individui, servizi o organizzazioni.
 
-### DATA SOURCE
+### FONTE DI DATI (DATA SOURCE)
 
 Una fonte di dati raccoglie ed elabora i dati personali che gli altri ruoli (incluse le Persone) potrebbero desiderare di accedere e utilizzare.
 
-### DATA USING SERVICE
+### SERVIZIO CHE USA DATI (DATA USING SERVICE)
 
-Un dato che utilizza il servizio può essere autorizzato a recuperare e utilizzare i dati personali da una o più fonti di dati.
+Un servizio che utilizza dati può essere autorizzato a recuperare e utilizzare i dati personali da una o più fonti di dati.
 
-### PERSONAL DATA OPERATOR
+### OPERATORE DI DATI PERSONALI (PERSONAL DATA OPERATOR)
 
 Un operatore di dati personali consente alle persone di accedere, gestire e utilizzare i propri dati personali in modo sicuro, nonché di controllare il flusso di dati personali con e tra le origini e i dati dei dati utilizzando i servizi. Gli individui possono essere i loro operatori. In altri casi, gli operatori non utilizzano le informazioni stesse, ma abilitano la connettività e la condivisione sicura dei dati tra gli altri ruoli nell'ecosistema.
 
-## 3. I PRINCIPI MYDATA: COSA VOGLIAMO RAGGIUNGERE
+## 3. I PRINC&Igrave;PI MYDATA: COSA VOGLIAMO OTTENERE
 
-Per produrre i cambiamenti necessari per un approccio incentrato sull'uomo ai dati personali, ci impegniamo a lavorare per difendere i seguenti principi:
+Per produrre i cambiamenti necessari per un approccio ai dati personali incentrato sulla persona, ci impegniamo a lavorare per difendere i seguenti princ&igrave;pi:
 
-### 3.1 IL CONTROLLO HUMAN-CENTRIC DEI DATI PERSONALI
+### 3.1 IL CONTROLLO DEI DATI PERSONALI INCENTRATO SULLA PERSONA
 
-Gli individui dovrebbero essere attori responsabilizzati nella gestione delle loro vite personali sia online che offline. Dovrebbero essere forniti dei mezzi pratici per capire e controllare efficacemente chi ha accesso ai dati su di loro e come viene utilizzato e condiviso.
+Gli individui devono essere attori responsabilizzati nella gestione delle loro vite personali, sia online che offline. Devono essere provvisti di mezzi pratici per capire e controllare efficacemente chi ha accesso ai dati su di loro e come vengono utilizzati e condivisi.
 
 Vogliamo che la privacy, la sicurezza dei dati e la minimizzazione dei dati diventino prassi standard nella progettazione di applicazioni. Vogliamo che le organizzazioni consentano alle persone di **comprendere le politiche sulla privacy** e come attivarle. Vogliamo che le persone **abbiano il potere di dare, negare o revocare il loro consenso** a condividere i dati sulla base di una chiara comprensione del perché, come e per quanto tempo verranno utilizzati i loro dati. In definitiva, vogliamo che i termini e le condizioni per l'utilizzo dei dati personali siano negoziabili in modo equo tra individui e organizzazioni.
 
 ### 3.2 L'INDIVIDUO COME PUNTO DI INTEGRAZIONE
 
-Il valore dei dati personali cresce esponenzialmente con la loro diversità; così come fa la minaccia alla privacy. Questa contraddizione può essere risolta se gli individui diventano gli "hub" in cui, o attraverso i quali avviene il **cross-referencing dei dati personali**.
+Il valore dei dati personali cresce esponenzialmente con la loro diversità; così come il rischio per la privacy. Questa contraddizione può essere risolta se gli individui diventano i "punti di integrazione" - o "hub" - in cui, o attraverso i quali avviene il **cross-referencing dei dati personali**.
 
-Consentendo agli individui di avere una visione a 360 gradi dei propri dati e agire da "punto di integrazione", vogliamo abilitare una nuova generazione di strumenti e servizi che forniscano una profonda personalizzazione e creino nuove conoscenze basate sui dati, senza compromettere la privacy o aumentare la quantità di dati personali in circolazione.
+Consentendo agli individui di avere una visione a 360 gradi dei propri dati e agire da hub, vogliamo abilitare una nuova generazione di strumenti e servizi che forniscano una profonda personalizzazione e creino nuove conoscenze basate sui dati, senza compromettere la privacy o aumentare la quantità di dati personali in circolazione.
 
-### 3.3 RESPONSABILIZZAZIONE DEL SINGOLO
+### 3.3 RESPONSABILIZZAZIONE DELL'INDIVIDUO
 
 In una società basata sui dati, come in qualsiasi società, le persone non dovrebbero essere viste come clienti o utenti di servizi e applicazioni predefiniti. Dovrebbero essere considerati **agenti liberi e autonomi**, in grado di stabilire e perseguire i propri obiettivi. Dovrebbero avere **iniziativa e possibilità di agire**.
 
-Vogliamo che le persone **siano in grado di gestire in modo sicuro i propri dati** personali nel loro modo preferito. Intendiamo aiutare le persone a disporre degli strumenti, delle capacità e dell'assistenza necessarie per trasformare i propri dati personali in informazioni utili e conoscenza per prendere decisioni. Riteniamo che queste siano le condizioni preliminari per relazioni corrette e vantaggiose basate sui dati.
+Vogliamo che gli individui **siano in grado di gestire in modo sicuro i propri dati personali** nel loro modo preferito. Intendiamo aiutare le persone a disporre degli strumenti, delle capacità e dell'assistenza necessarie per trasformare i propri dati personali in informazioni utili e conoscenza per prendere decisioni. Riteniamo che queste siano le condizioni preliminari per relazioni corrette e vantaggiose basate sui dati.
 
-### 3.4 PORTABILITA': ACCESSO E RIUSO
+### 3.4 PORTABILIT&Agrave;: ACCESSO E RIUSO
 
 La portabilità dei dati personali, che consente alle persone di ottenere e riutilizzare i propri dati personali per i propri scopi e tra diversi servizi, è la chiave per passare da dati in silos chiusi a dati che diventano risorse riutilizzabili. La portabilità dei dati non dovrebbe essere solo un diritto legale, ma combinato con mezzi pratici.
 
-Vogliamo consentire alle persone di **trasferire in modo efficace i propri dati personali**, sia scaricandoli sui loro dispositivi personali, sia trasmettendoli ad altri servizi. Intendiamo aiutare Data Sources a rendere questi dati disponibili in modo sicuro e semplice, in un formato strutturato, comunemente usato e leggibile da un dispositivo. Questo vale per tutti i dati personali indipendentemente dalla base legale (contratto, consenso, interesse legittimo, ecc.) Della raccolta dei dati, con possibili eccezioni per i dati arricchiti.
+Vogliamo consentire alle persone di **trasferire in modo efficace i propri dati personali**, sia scaricandoli sui loro dispositivi personali, sia trasmettendoli ad altri servizi. Intendiamo aiutare le Fonti Di Dati a rendere questi dati disponibili in modo sicuro e semplice, in un formato strutturato, comunemente usato e leggibile da dispositivi elettronici. Questo vale per tutti i dati personali indipendentemente dalla base legale della raccolta dei dati (contratto, consenso, interesse legittimo, ecc.), con possibili eccezioni per i dati arricchiti.
 
-### 3.5 TRASPARENZA E RESPONSABILITA'
+### 3.5 TRASPARENZA E RESPONSABILIT&Agrave;
 
-Le organizzazioni che utilizzano i dati di una persona dovrebbero dire cosa fanno con loro e perché, e dovrebbero fare ciò che dicono. Dovrebbero assumersi la responsabilità delle conseguenze intenzionali, nonché non intenzionali, della conservazione e dell'utilizzo di dati personali, inclusi, ma non limitati a, incidenti di sicurezza e consentire alle persone di chiamarli con questa responsabilità.
+Le organizzazioni che utilizzano i dati di una persona dovrebbero dichiarare cosa fanno con quei dati e perché, e dovrebbero fare ciò che dichiarano. Dovrebbero assumersi la responsabilità delle conseguenze intenzionali, nonché non intenzionali, della conservazione e dell'utilizzo di dati personali, inclusi, ma non limitati a, incidenti di sicurezza e consentire alle persone di chiamarli a questa responsabilità.
 
 Vogliamo assicurarci che i **termini e le politiche sulla privacy riflettano la realtà**, in un modo che consenta alle persone di fare scelte informate in anticipo e possano essere verificate durante e dopo le operazioni. Vogliamo consentire alle persone di **capire come e perché vengono prese le decisioni** basate sui loro dati. Vogliamo creare canali facili da usare e sicuri affinché le persone possano **vedere e controllare ciò che accade ai loro dati**, avvisarli di eventuali problemi e contestare le decisioni basate su algoritmi.
 
-### 3.6 INTEROPERABILITA'
+### 3.6 INTEROPERABILIT&Agrave;
 
 Lo scopo dell'interoperabilità è ridurre l'attrito nel flusso di dati dalle fonti di dati ai dati che utilizzano i servizi, eliminando al contempo le possibilità di blocco dei dati. Dovrebbe essere raggiunto guidando continuamente verso **pratiche commerciali e standard tecnici comuni**.
 
 Al fine di massimizzare gli effetti positivi degli ecosistemi aperti, lavoreremo continuamente verso l'interoperabilità di dati, API aperte, protocolli, applicazioni e infrastrutture, in modo che tutti i dati personali siano **portatili e riutilizzabili**, senza perdere il controllo dell'utente. Ci baseremo su standard, ontologie, librerie e schemi comunemente accettati, oppure aiuteremo a svilupparne di nuovi, se necessario.
 
-## 4. ACTIONS: WHAT SHOULD HAPPEN NOW
+## 4. AZIONI: COSA DOVREMMO FARE ORA
 
-* **Firma la Dichiarazione**, come individuo e / o come organizzazione. Questa Dichiarazione è scritta nel tempo futuro: se la tua organizzazione non è del tutto lì, ma è impegnata a muoversi in questa direzione, dovrebbe comunque firmarla!
+* **Firma la Dichiarazione**, a titolo personale o per l'organizzazione che rappresenti. Questa Dichiarazione è scritta "al futuro": se la tua organizzazione non &egrave; ancora allineata a tutti i suoi princ&igrave;pi, ma è impegnata a muoversi in questa direzione, dovrebbe comunque firmarla!
 
-* **Commenta la dichiarazione**. Questa Dichiarazione si evolverà nel tempo, in base alle tue idee e all'esperienza pratica. Ci sarà una revisione iniziale dopo 6 mesi.
+* **Commenta la dichiarazione**. Questa Dichiarazione evolverà nel tempo, in base alle tue idee e all'esperienza pratica. Ci sarà una revisione iniziale dopo 6 mesi.
 
-* **Usa la Dichiarazione** per promuovere i tuoi progetti e le tue intenzioni. Basare il proprio quadro di fiducia o i termini di servizio su di esso. Usalo per fare lobby e convincere clienti, partner, stakeholder, ecc.
+* **Usa la Dichiarazione** per promuovere i tuoi progetti e le tue intenzioni. Basate il vostro modello di fiducia, o i termini di servizio su di essa. Usala per fare lobby e convincere clienti, partner, parti interessate, ecc.
 
-## REFERENCES
+## RIFERIMENTI
 
-Questa Dichiarazione di Principi si basa su molte fonti di ispirazione, le più significative sono:
+Questa Dichiarazione di Princ&igrave;pi si basa su molte fonti di ispirazione; tra di esse, le più significative sono:
 
-* The [MyData Principles](https://github.com/okffi/mydata) (Open Knowledge Finland)
+* I ["MyData Principles"](https://github.com/okffi/mydata) (Open Knowledge Finland, in lingua Inglese)
 
-* The [MesInfos Self Data Charter](https://docs.google.com/document/d/152JQmJjEoJ2U5ikwyq2e8hujjKukPC4baWhHITsJisM/edit#heading=h.qn9xmj8uw8ja) (Fing)
+* Il ["MesInfos Self Data Charter"](https://docs.google.com/document/d/152JQmJjEoJ2U5ikwyq2e8hujjKukPC4baWhHITsJisM/edit#heading=h.qn9xmj8uw8ja) (Fing, in lingua Inglese)
 
-* The [Project VRM Principles](https://docs.google.com/document/d/152JQmJjEoJ2U5ikwyq2e8hujjKukPC4baWhHITsJisM/edit#heading=h.wwuoeihq76ji) (Project VRM)
+* I ["Project VRM Principles"](https://docs.google.com/document/d/152JQmJjEoJ2U5ikwyq2e8hujjKukPC4baWhHITsJisM/edit#heading=h.wwuoeihq76ji) (Project VRM, in Lingua Inglese)
 
-* The [ODI data sharing principles](https://docs.google.com/document/d/152JQmJjEoJ2U5ikwyq2e8hujjKukPC4baWhHITsJisM/edit#heading=h.h9z8majrp45k) (Open Data Institute)
+* Gli ["ODI data sharing principles"](https://docs.google.com/document/d/152JQmJjEoJ2U5ikwyq2e8hujjKukPC4baWhHITsJisM/edit#heading=h.h9z8majrp45k) (Open Data Institute, in Lingua Inglese)
 
-* The [Personal Data Ecosystem Roles & Definitions](http://pde.cc/) (PDEC)
+* I ["Personal Data Ecosystem Roles & Definitions"](http://pde.cc/) (PDEC, in lingua Inglese)


### PR DESCRIPTION
In this edit I have been very careful not to change the meaning from the English version, whose language in my opinion is quite weak in many points. I look forward to a major revision of that, too.

In the meantime, I am proposing many improvements to the Italian version, among which are:

- reduction in use of the word "individuo" (individual) and "uomo" (man) favouring "persona" (person) instead; in Italian, "individual" has a stronger connotation than in English; the change comes to a similar concern to the one described [here](https://mydataglobal.slack.com/archives/C88ECDH5J/p1518778119000022)

- a general attempt to make language consistent (e.g. using "fiducia" instead of "trust" across the whole document)

- fixes of the many points where the previous translator had forgotten bits that were left in English

Hope it's useful.